### PR TITLE
Remove 'CHR=' in stats output.

### DIFF
--- a/filter_DELLY_pair.pl
+++ b/filter_DELLY_pair.pl
@@ -115,7 +115,7 @@ while (my $line = <IN>){
 		$mapq = $mapqs[1];
 	    }
 	}
-	my $chr2 = $info[5];
+	my (undef, $chr2) = split('=\s*', $info[5]);
 	my $size = $pos2 - $data[1];
 	next if ($mapq < $min_mapq); #sufficient quality
 


### PR DESCRIPTION
Hello Ruben,

This change removes the `CHR=` part in the stats output file.

Kind regards,
Roel